### PR TITLE
Changed how the year dropdown is indicated

### DIFF
--- a/components/Select/Select.module.scss
+++ b/components/Select/Select.module.scss
@@ -28,7 +28,7 @@
 
 .underline {
     position: absolute;
-    bottom: 0;
+    bottom: 2px;
     left: 0;
     width: 75%; 
     height: 2.5px; 
@@ -36,6 +36,12 @@
     animation: bounce-animation 4s ease-in-out infinite; 
 }
 
+@media (max-width: 768px) {
+    .underline {
+        bottom: 4px; 
+        height: 2.5px; 
+    }
+}
 .dropdownBtn::before {
     content: "";
     position: absolute;

--- a/components/Select/Select.module.scss
+++ b/components/Select/Select.module.scss
@@ -9,7 +9,31 @@
         background: none;
         padding: 0.25rem 2.25rem 0.25rem 0.5rem;
         cursor: pointer;
+        position: relative; 
+        overflow: hidden; 
     }
+}
+
+@keyframes bounce-animation {
+    0% {
+        transform: translateX(0);
+    }
+    50% {
+        transform: translateX(25%);
+    }
+    100% {
+        transform: translateX(0);
+    }
+}
+
+.underline {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 75%; 
+    height: 2.5px; 
+    background-color: #68c8bf; 
+    animation: bounce-animation 4s ease-in-out infinite; 
 }
 
 .dropdownBtn::before {
@@ -18,9 +42,6 @@
     inset: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba($color: #000000, $alpha: 0.2);
-    transition: opacity .3s;
-    opacity: 0.5;
     z-index: 2;
     border-radius: 10px;
     pointer-events: none;
@@ -37,10 +58,11 @@
     height: 0.75rem;
     top: calc(50% - 0.5rem);
     right: 0.75rem;
+    
     border: solid #68c8bf;
     border-width: 0 3px 3px 0;
     transform: rotate(45deg);
-    transition: transform .3s;
+    transition: transform 0.3s; 
     pointer-events: none;
 }
 

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -23,15 +23,16 @@ const Select: React.FC<SelectProps> = ({
     return (
         <div className={styles.select}>
             <button
-                onClick={() => setOpen(previous => !previous)}
+                onClick={() => setOpen((previous) => !previous)}
                 className={`${styles.dropdownBtn} ${
                     open ? styles.openSelect : ""
                 }`}
             >
                 <h1 className={titleStyle}>{selected}</h1>
+                <div className={styles.underline}></div>
             </button>
             <div className={styles.dropdown} style={{ opacity: open ? 1 : 0 }}>
-                {options.map(option => (
+                {options.map((option) => (
                     <button
                         key={option}
                         onClick={() => {


### PR DESCRIPTION
Changed how the year text in the team tab is indicated. The bar/underline beneath the text is animated an slides from left to right infinitely.
<img width="661" alt="Screenshot 2024-10-20 at 2 55 03 PM" src="https://github.com/user-attachments/assets/03c391ce-c4dd-4154-9c4f-ff6246c7d7ef">
